### PR TITLE
Add Dockerfile for Python 3.12 and Ubuntu LTS-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY ./OpenManus/requirements.txt /app/requirements.txt
+
+RUN pip install -r requirements.txt

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+
+services:
+  openmanus:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    working_dir: /app
+    command: python app.py


### PR DESCRIPTION
Add a Dockerfile to the repository.

* Use `python:3.12-slim` as the base image
* Set the working directory to `/app`
* Copy `./OpenManus/requirements.txt` to `/app/requirements.txt`
* Run `pip install -r requirements.txt`

